### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/autoship-client/components/add-repository-form.tsx
+++ b/autoship-client/components/add-repository-form.tsx
@@ -15,7 +15,16 @@ const formSchema = z.object({
   repoUrl: z
     .string()
     .url({ message: "Please enter a valid URL" })
-    .refine((url) => url.includes("github.com"), "Please enter a valid GitHub repository URL"),
+    .refine((url) => {
+      try {
+        const parsed = new URL(url)
+        const host = parsed.hostname.toLowerCase()
+        const allowedHosts = ["github.com", "www.github.com"]
+        return allowedHosts.includes(host)
+      } catch {
+        return false
+      }
+    }, "Please enter a valid GitHub repository URL"),
 })
 
 export function AddRepositoryForm() {


### PR DESCRIPTION
Potential fix for [https://github.com/Ashmit-Kumar/Auto-Ship/security/code-scanning/1](https://github.com/Ashmit-Kumar/Auto-Ship/security/code-scanning/1)

In general, the problem is that the current check treats the URL as an opaque string and looks for `"github.com"` anywhere. Instead, we should parse the URL and validate its hostname (and optionally its path structure) against a whitelist of allowed GitHub hosts. This ensures that `"github.com"` cannot be smuggled in via the path, query string, or as part of another domain.

The best fix with minimal behavioral change is to replace `.refine((url) => url.includes("github.com"), ...)` with a refinement that:

1. Uses the built‑in `URL` constructor to parse the URL string.
2. Extracts the `hostname` property.
3. Checks that the hostname is exactly one of the allowed GitHub domains, e.g. `github.com` or `www.github.com` (and potentially common GitHub variants if desired, such as `gist.github.com`).
4. Catches parsing errors and treats them as invalid.

We only need to modify the `formSchema` definition in `autoship-client/components/add-repository-form.tsx`. No new imports are necessary because `URL` is available in modern browsers and in Next.js client components. The refined schema will reject URLs that merely contain `github.com` in non‑host parts or as a misleading super‑domain, while still accepting legitimate GitHub repository URLs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
